### PR TITLE
Clean up Android configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,12 @@ compile_commands.json
 android/build
 android/.cxx
 
+# Ignore intellij configuration files and directories
+.idea
+*.iml
+
+# Local configuration file (sdk path, etc)
+local.properties
+
 # Ignore build folder, need to fix gradlew config because this should be android/build
 build

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
-        versionCode 3
+        versionCode 100003
         versionName '1.0.3'
         setProperty("archivesBaseName", "godotopenxr.${versionName}")
 
@@ -47,7 +47,7 @@ android {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlinVersion")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlinVersion")
     if (rootProject.findProject(":godot:lib") != null) {
         compileOnly(project(":godot:lib"))
     } else {

--- a/android/godot_openxr.gdap
+++ b/android/godot_openxr.gdap
@@ -2,4 +2,4 @@
 
 name="GodotOpenXR"
 binary_type="local"
-binary="godotopenxr_1.0.3-release.aar"
+binary="godotopenxr.1.0.3-release.aar"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,7 +3,18 @@
         xmlns:tools="http://schemas.android.com/tools"
         package="org.godotengine.plugin.vr.openxr">
 
+    <uses-feature
+        android:name="android.hardware.vr.headtracking"
+        android:required="true"
+        android:version="1"
+        tools:node="replace"/>
+
     <application>
+
+        <meta-data
+            android:name="com.samsung.android.vr.application.mode"
+            android:value="vr_only"
+            tools:node="replace" />
 
         <meta-data
                 android:name="org.godotengine.plugin.v1.GodotOpenXR"

--- a/android/src/main/java/org/godotengine/plugin/vr/openxr/GodotOpenXRPlugin.kt
+++ b/android/src/main/java/org/godotengine/plugin/vr/openxr/GodotOpenXRPlugin.kt
@@ -1,0 +1,19 @@
+package org.godotengine.plugin.vr.openxr
+
+import org.godotengine.godot.Godot
+import org.godotengine.godot.plugin.GodotPlugin
+
+class GodotOpenXRPlugin(godot: Godot) : GodotPlugin(godot) {
+
+  companion object {
+    init {
+      System.loadLibrary("openxr_loader")
+      System.loadLibrary("godot_openxr")
+    }
+  }
+
+  override fun getPluginName() = "GodotOpenXR"
+
+  override fun getPluginGDNativeLibrariesPaths() =
+    setOf("addons/godot-openxr/godot_openxr.gdnlib")
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$versions.gradlePluginVersion"
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/config.gradle
+++ b/config.gradle
@@ -1,9 +1,9 @@
 ext.versions = [
-    gradlePluginVersion: '4.1.0',
+    gradlePluginVersion: '4.2.1',
     compileSdk         : 30,
     minSdk             : 18,
     targetSdk          : 30,
-    buildTools         : '30.0.1',
-    kotlinVersion      : '1.4.31',
-    ndkVersion         : "21.3.6528147"
+    buildTools         : '30.0.3',
+    kotlinVersion      : '1.5.20',
+    ndkVersion         : "21.4.7075529"
 ]

--- a/demo/addons/godot-openxr/godot_openxr.gdnlib
+++ b/demo/addons/godot-openxr/godot_openxr.gdnlib
@@ -9,10 +9,10 @@ reloadable=false
 
 Windows.64="res://addons/godot-openxr/bin/win64/libgodot_openxr.dll"
 X11.64="res://addons/godot-openxr/bin/linux/libgodot_openxr.so"
-Android.64="res://addons/godot-openxr/bin/android/libgodot_openxr.aar"
+Android.64="res://addons/godot-openxr/bin/android/libgodot_openxr.so"
 
 [dependencies]
 
 Windows.64=[ "res://addons/godot-openxr/bin/win64/openxr_loader.dll" ]
 X11.64=[  ]
-Android.64=[  ]
+Android.64=[ "res://addons/godot-openxr/bin/android/libopenxr_loader.so" ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Several cleanups to properly setup and register the Android components with Godot.
It's yet to be tested though, I'll take a look at that tomorrow.

I also decided with sticking to the current directory structure as it simplifies setup within Android Studio as well.